### PR TITLE
feat: Order 도메인 및 관리자 매출 조회 구현

### DIFF
--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/ctrl/OrderController.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/ctrl/OrderController.java
@@ -1,0 +1,28 @@
+package com.cafe.order.domain.order.ctrl;
+
+import com.cafe.order.domain.order.service.OrderService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    // READ : 전체 매출 조회
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("sales", orderService.getSalesByStore());
+        return "sales/list";
+    }
+
+
+
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/dto/Order.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/dto/Order.java
@@ -1,0 +1,62 @@
+package com.cafe.order.domain.order.dto;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Order {
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)", name = "order_id")
+    private UUID orderId;
+
+    @Column(nullable = false, name = "customer_id")
+    private String customerId;
+
+    @Column(nullable = false, name = "store_id")
+    private Integer storeId;
+
+    @Column(nullable = false, updatable = false, name = "order_time")
+    private LocalDateTime orderTime;
+
+    @Column(nullable = false, name = "total_price")
+    private Integer totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(name = "waiting_number")
+    private Integer waitingNumber;
+
+    // 신규 주문 생성자
+    public Order(String customerId, Integer storeId, Integer totalPrice, OrderStatus status) {
+        this.orderId = UUID.randomUUID();
+        this.customerId = customerId;
+        this.storeId = storeId;
+        this.orderTime = LocalDateTime.now();
+        this.totalPrice = totalPrice;
+        this.status = status;
+    }
+
+    // DB 로드 생성자
+    public Order(UUID orderId, String customerId, Integer storeId, LocalDateTime orderTime, Integer totalPrice, OrderStatus status, Integer waitingNumber) {
+        this.orderId = orderId;
+        this.customerId = customerId;
+        this.storeId = storeId;
+        this.orderTime = orderTime;
+        this.totalPrice = totalPrice;
+        this.status = status;
+        this.waitingNumber = waitingNumber;
+    }
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/dto/OrderStatus.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/dto/OrderStatus.java
@@ -1,0 +1,18 @@
+package com.cafe.order.domain.order.dto;
+
+public enum OrderStatus {
+    ORDER_PLACED("주문 접수"),
+    PREPARING("준비중"),
+    READY("준비완료"),
+    COMPLETED("픽업완료");
+
+    private final String displayName;
+
+    OrderStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;}
+
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/dto/SalesDto.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/dto/SalesDto.java
@@ -1,0 +1,37 @@
+package com.cafe.order.domain.order.dto;
+
+public class SalesDto {
+    private String storeName; // 지점명
+    private Integer orderCount; // 주문 수
+    private Integer totalSales; // 총 매출
+
+    public SalesDto(String storeName, Integer orderCount, Integer totalSales) {
+        this.storeName = storeName;
+        this.orderCount = orderCount;
+        this.totalSales = totalSales;
+    }
+
+    public String getStoreName() {
+        return storeName;
+    }
+
+    public void setStoreName(String storeName) {
+        this.storeName = storeName;
+    }
+
+    public Integer getOrderCount() {
+        return orderCount;
+    }
+
+    public void setOrderCount(Integer orderCount) {
+        this.orderCount = orderCount;
+    }
+
+    public Integer getTotalSales() {
+        return totalSales;
+    }
+
+    public void setTotalSales(Integer totalSales) {
+        this.totalSales = totalSales;
+    }
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/repo/InMemoryOrderRepository.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/repo/InMemoryOrderRepository.java
@@ -1,0 +1,118 @@
+package com.cafe.order.domain.order.repo;
+
+import com.cafe.order.domain.order.dto.Order;
+import com.cafe.order.domain.order.dto.OrderStatus;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Repository
+public class InMemoryOrderRepository {
+
+    private final List<Order> orders;
+
+    // 생성자로 초기 데이터 로드
+    public InMemoryOrderRepository() {
+        this.orders = new ArrayList<>();
+
+        // 강남점 (storeId=1) 주문
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 1,
+            LocalDateTime.now().minusDays(2), 5000, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 1,
+            LocalDateTime.now().minusDays(2), 11000, OrderStatus.COMPLETED, 2
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 1,
+            LocalDateTime.now().minusDays(1), 6500, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 1,
+            LocalDateTime.now(), 4500, OrderStatus.PREPARING, 1
+        ));
+
+        // 홍대점 (storeId=2) 주문
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 2,
+            LocalDateTime.now().minusDays(3), 10000, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 2,
+            LocalDateTime.now().minusDays(1), 12000, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 2,
+            LocalDateTime.now(), 5500, OrderStatus.READY, 1
+        ));
+
+        // 신촌점 (storeId=3) 주문
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 3,
+            LocalDateTime.now().minusDays(4), 15000, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 3,
+            LocalDateTime.now().minusDays(2), 6000, OrderStatus.COMPLETED, 2
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 3,
+            LocalDateTime.now().minusDays(1), 11500, OrderStatus.COMPLETED, 3
+        ));
+
+        // 잠실점 (storeId=4) 주문
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 4,
+            LocalDateTime.now().minusDays(1), 9000, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 4,
+            LocalDateTime.now(), 5000, OrderStatus.ORDER_PLACED, 1
+        ));
+
+        // 판교점 (storeId=5) 주문
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 5,
+            LocalDateTime.now().minusDays(5), 12500, OrderStatus.COMPLETED, 1
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer2", 5,
+            LocalDateTime.now().minusDays(3), 18000, OrderStatus.COMPLETED, 2
+        ));
+        orders.add(new Order(
+            UUID.randomUUID(), "customer1", 5,
+            LocalDateTime.now().minusDays(1), 7000, OrderStatus.COMPLETED, 3
+        ));
+    }
+
+    // READ : status로 필터링 (람다식)
+    public List<Order> findByStatus(OrderStatus status) {
+        return orders.stream()
+            .filter(order -> order.getStatus() == status)
+            .collect(Collectors.toList());
+    }
+
+    // READ : status로 필터링 (자바 원시 코드)
+    @Deprecated
+    public List<Order> findByStatusBasedRoop(OrderStatus status) {
+        List<Order> result = new ArrayList<>();
+
+        for (Order order : orders) {
+            if (order.getStatus() == status) {
+                result.add(order);
+            }
+        }
+
+        return result;
+    }
+
+
+
+
+
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/repo/JpaOrderRepository.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/repo/JpaOrderRepository.java
@@ -1,0 +1,16 @@
+package com.cafe.order.domain.order.repo;
+
+import com.cafe.order.domain.order.dto.Order;
+import com.cafe.order.domain.order.dto.OrderStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+//@Repository
+public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
+
+
+    List<Order> findByStatus(OrderStatus status);
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/repo/SqlOrderRepository.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/repo/SqlOrderRepository.java
@@ -1,0 +1,52 @@
+package com.cafe.order.domain.order.repo;
+
+import com.cafe.order.common.util.UUIDUtils;
+import com.cafe.order.domain.order.dto.Order;
+import com.cafe.order.domain.order.dto.OrderStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+//@Repository
+public class SqlOrderRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public SqlOrderRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    // READ : status = COMPLETE인 전체 지점 매출 조회
+    public List<Order> findByStatus(OrderStatus status) {
+        String sql = "SELECT order_id, customer_id, store_id, order_time, total_price, status, waiting_number FROM orders WHERE status = ?";
+
+        return jdbcTemplate.query(sql, orderRowMapper(), status.name());
+    }
+
+
+    // ResultSet -> Order 변환
+    public RowMapper<Order> orderRowMapper() {
+        return ((rs, rowNum) -> {
+            Order order = new Order();
+
+            // UUID 변환
+            byte[] orderIdBytes = rs.getBytes("order_id");
+            order.setOrderId(UUIDUtils.convertBytesToUUID(orderIdBytes));
+
+            order.setCustomerId(rs.getString("customer_id"));
+            order.setStoreId(rs.getInt("store_id"));
+            order.setOrderTime(rs.getTimestamp("order_time").toLocalDateTime());
+            order.setTotalPrice(rs.getInt("total_price"));
+            order.setStatus(OrderStatus.valueOf(rs.getString("status")));
+
+            // waitingNumber는 null 가능
+            int waitingNumber = rs.getInt("waiting_number");
+            order.setWaitingNumber(rs.wasNull() ? null : waitingNumber);
+
+            return order;
+        } );
+    }
+
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/service/OrderService.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/order/service/OrderService.java
@@ -1,0 +1,85 @@
+package com.cafe.order.domain.order.service;
+
+import com.cafe.order.domain.order.dto.Order;
+import com.cafe.order.domain.order.dto.OrderStatus;
+import com.cafe.order.domain.order.dto.SalesDto;
+import com.cafe.order.domain.order.repo.InMemoryOrderRepository;
+import com.cafe.order.domain.order.repo.JpaOrderRepository;
+import com.cafe.order.domain.order.repo.SqlOrderRepository;
+import com.cafe.order.domain.store.dto.Store;
+import com.cafe.order.domain.store.service.StoreService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class OrderService {
+
+//    private final JpaOrderRepository salesRepository;
+//    private final SqlOrderRepository salesRepository;
+    private final InMemoryOrderRepository salesRepository;
+
+    private final StoreService storeService;
+
+
+    public OrderService(InMemoryOrderRepository salesRepository, StoreService storeService) {
+        this.salesRepository = salesRepository;
+        this.storeService = storeService;
+    }
+
+    // READ : 전체 지점별 매출 조회
+    public List<SalesDto> getSalesByStore() {
+        // 1. COMPLETE된 주문만 가져오기
+        List<Order> orders = salesRepository.findByStatus(OrderStatus.COMPLETED);
+
+        // 2. storeId별 그룹핑 + 집계
+        Map<Integer, SalesData> salesMap = new HashMap<>();
+
+        for (Order order : orders) {
+            int storeId = order.getStoreId();
+            int price = order.getTotalPrice();
+
+            // 그룹핑 : storeId를 key로
+            if (!salesMap.containsKey(storeId)) {
+                salesMap.put(storeId, new SalesData());
+            }
+
+            // 집계 : count 증가, 금액 누적
+            SalesData data = salesMap.get(storeId);
+            data.orderCount++; // 주문수 +1
+            data.totalSales += price; // 매출 누적
+        }
+
+        // 3. Store 이름 조회 + DTO 반환
+        List<SalesDto> result = new ArrayList<>();
+        for (Map.Entry<Integer, SalesData> entry : salesMap.entrySet()) {
+            int storeId = entry.getKey();
+            SalesData data = entry.getValue();
+
+            // Store 조회
+            Store store = storeService.findById(storeId);
+
+            // DTO 생성
+            result.add(new SalesDto(
+                store.getName(), // 지점명
+                data.orderCount, //주문수
+                data.totalSales // 총매출
+            ));
+        }
+
+        return result;
+
+    }
+
+
+
+}
+
+// 집게용 임시 클래스
+class SalesData {
+    int orderCount = 0;
+    int totalSales = 0;
+}

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/user/repo/JpaUserRepository.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/user/repo/JpaUserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-//@Repository
+@Repository
 public interface JpaUserRepository extends JpaRepository<User, Integer> {
 
     // role 필터링

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/user/repo/SqlUserRepository.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/user/repo/SqlUserRepository.java
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
-@Repository
+//@Repository
 public class SqlUserRepository {
 
     private final JdbcTemplate jdbcTemplate;

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/user/service/UserService.java
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/java/com/cafe/order/domain/user/service/UserService.java
@@ -18,13 +18,13 @@ import java.util.stream.Collectors;
 @Service
 public class UserService {
 
-//  private final JpaUserRepository userRepository;
-    private final SqlUserRepository userRepository;
+  private final JpaUserRepository userRepository;
+//    private final SqlUserRepository userRepository;
 //    private final InMemoryUserRepository userRepository;
 
   private final StoreService storeService;
 
-  public UserService(SqlUserRepository userRepository, StoreService storeService) {
+  public UserService(JpaUserRepository userRepository, StoreService storeService) {
     this.userRepository = userRepository;
     this.storeService = storeService;
   }
@@ -86,8 +86,8 @@ public class UserService {
 
     seller.setStoreId(storeId);
 
-//    return userRepository.save(seller); // JPA
-        return userRepository.update(seller); // SQL, InMemory
+    return userRepository.save(seller); // JPA
+//        return userRepository.update(seller); // SQL, InMemory
   }
 
   // DELETE : 판매자 계정 삭제

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/resources/data.sql
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/resources/data.sql
@@ -37,3 +37,41 @@ VALUES ('seller1', 'qwer1234', 'SELLER', 1),
 INSERT INTO users (username, password, role, store_id)
 VALUES ('customer1', 'qwer1234', 'CUSTOMER', NULL),
        ('customer2', 'qwer1234', 'CUSTOMER', NULL);
+
+
+-- 주문 테스트 데이터
+
+-- 강남점 (storeId=1) 주문
+INSERT INTO orders (order_id, customer_id, store_id, order_time, total_price, status, waiting_number)
+VALUES
+    (RANDOM_UUID(), 'customer1', 1, DATEADD('DAY', -2, NOW()), 5000, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer2', 1, DATEADD('DAY', -2, NOW()), 11000, 'COMPLETED', 2),
+    (RANDOM_UUID(), 'customer1', 1, DATEADD('DAY', -1, NOW()), 6500, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer2', 1, NOW(), 4500, 'PREPARING', 1);
+
+-- 홍대점 (storeId=2) 주문
+INSERT INTO orders (order_id, customer_id, store_id, order_time, total_price, status, waiting_number)
+VALUES
+    (RANDOM_UUID(), 'customer1', 2, DATEADD('DAY', -3, NOW()), 10000, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer2', 2, DATEADD('DAY', -1, NOW()), 12000, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer1', 2, NOW(), 5500, 'READY', 1);
+
+-- 신촌점 (storeId=3) 주문
+INSERT INTO orders (order_id, customer_id, store_id, order_time, total_price, status, waiting_number)
+VALUES
+    (RANDOM_UUID(), 'customer2', 3, DATEADD('DAY', -4, NOW()), 15000, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer1', 3, DATEADD('DAY', -2, NOW()), 6000, 'COMPLETED', 2),
+    (RANDOM_UUID(), 'customer2', 3, DATEADD('DAY', -1, NOW()), 11500, 'COMPLETED', 3);
+
+-- 잠실점 (storeId=4) 주문
+INSERT INTO orders (order_id, customer_id, store_id, order_time, total_price, status, waiting_number)
+VALUES
+    (RANDOM_UUID(), 'customer1', 4, DATEADD('DAY', -1, NOW()), 9000, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer2', 4, NOW(), 5000, 'ORDER_PLACED', 1);
+
+-- 판교점 (storeId=5) 주문
+INSERT INTO orders (order_id, customer_id, store_id, order_time, total_price, status, waiting_number)
+VALUES
+    (RANDOM_UUID(), 'customer1', 5, DATEADD('DAY', -5, NOW()), 12500, 'COMPLETED', 1),
+    (RANDOM_UUID(), 'customer2', 5, DATEADD('DAY', -3, NOW()), 18000, 'COMPLETED', 2),
+    (RANDOM_UUID(), 'customer1', 5, DATEADD('DAY', -1, NOW()), 7000, 'COMPLETED', 3);

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/resources/templates/admin/dashboard.html
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/resources/templates/admin/dashboard.html
@@ -24,7 +24,7 @@
 
     <div>
         <h3 style="display: inline">4. 매출 관리</h3>
-        <a>이동</a>
+        <a href="/admin/orders">이동</a>
     </div>
 
     <div>

--- a/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/resources/templates/sales/list.html
+++ b/CafeOrder/cafe_order_spring/cafe-order-spring/src/main/resources/templates/sales/list.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>매출 조회</title>
+</head>
+<body>
+    <h1>전체 매출 조회</h1>
+
+    <div th:if="${sales.isEmpty()}">
+        <p>매출이 존재하지 않습니다.</p>
+    </div>
+
+    <table th:unless="${sales.isEmpty()}">
+        <tr>
+            <td>지점명</td>
+            <td>주문 수</td>
+            <td>총 매출</td>
+        </tr>
+
+        <tr th:each="s : ${sales}">
+            <th th:text="${s.getStoreName()}">지점명</th>
+            <th th:text="${s.getOrderCount()}">주문 수</th>
+            <th th:text="${s.getTotalSales()}">총 매출</th>
+        </tr>
+
+    </table>
+
+<div>
+    <a href="/admin">관리자 메뉴로 돌아가기</a>
+</div>
+
+
+</body>
+</html>


### PR DESCRIPTION
- Order Entity 및 OrderStatus Enum 추가
- SalesDto 생성 (지점별 매출 집계용)
- OrderController: 전체 매출 조회 페이지
- OrderService: storeId별 그룹핑 및 집계 로직
- 3가지 Repository 구현
  * JpaOrderRepository (JPA 자동 쿼리)
  * SqlOrderRepository (JDBC 수동 SQL)
  * InMemoryOrderRepository (List 기반)
- sales/list.html 추가
- UUID 변환 유틸리티 (UUIDUtils)
- 더미 데이터 추가 (data.sql)